### PR TITLE
Allow GitHub Actions to pass secrets from CI/CD to CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -42,6 +42,7 @@ jobs:
       - workflow_config
 
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   # -----END CI Job-----
 


### PR DESCRIPTION
The CI workflow requires access to the `CODECOV_TOKEN` GitHub secret.

Bug originally introduced in revision 8b5d1037cd4ad34289458a2fb86d8f961c14901f.