### PR TITLE
deps: Update `setuptools` from ≤69.1.0 to 71.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@
 
 [build-system]
 requires = [
-  "setuptools==68.0.0",
+  "setuptools==71.1.0",
   "wheel==0.41.2",
 ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
 bumpversion==0.5.3
-setuptools==69.1.0
+setuptools==71.1.0
 twine==4.0.2
 wheel==0.42.0


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/setuptools/71.1.0/)
- [Release notes](https://github.com/pypa/setuptools/releases/tag/v71.1.0)
- [Changelog](https://github.com/pypa/setuptools/blob/v71.1.0/NEWS.rst#v7110)
- [Commits](https://github.com/pypa/setuptools/compare/v69.1.0...v71.1.0)