### PR TITLE
deps: Update `wheel` from ≤0.42.0 to 0.45.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,6 @@
 [build-system]
 requires = [
   "setuptools==71.1.0",
-  "wheel==0.41.2",
+  "wheel==0.45.0",
 ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -3,4 +3,4 @@
 bumpversion==0.5.3
 setuptools==71.1.0
 twine==4.0.2
-wheel==0.42.0
+wheel==0.45.0


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/wheel/0.45.0/)
- [Release notes](https://github.com/pypa/wheel/releases/tag/0.45.0)
- [Changelog](https://github.com/pypa/wheel/blob/0.45.0/docs/news.rst)
- [Commits](https://github.com/pypa/wheel/compare/0.42.0...0.45.0)