### PR TITLE
Replace `setup.py sdist` and `bdist_wheel` with `build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ build: ## Build Python package
 	$(PYTHON) setup.py build
 
 dist: build ## builds source and wheel package
-	python setup.py sdist
-	python setup.py bdist_wheel
+	python -m build --sdist
+	python -m build --wheel
 	twine check dist/*
 	ls -l dist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,6 @@ requires = [
   "wheel==0.45.0",
 ]
 build-backend = "setuptools.build_meta:__legacy__"
+
+[tool.distutils.bdist_wheel]
+universal = false

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+build==1.2.2.post1
 bumpversion==0.5.3
 setuptools==71.1.0
 twine==4.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 0


### PR DESCRIPTION
Setuptools has deprecated `python setup.py sdist` and `python setup.py bdist_wheel` in favor of `python -m build`.

This commit replaces the deprecated commands with the new `python -m build` command in `Makefile`, and moves the tool's configuration from `setup.cfg` to `pyproject.toml`.

See also: [How to modernize a `setup.py` based project?](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/) ([GitHub](https://github.com/pypa/packaging.python.org/blob/afb69f3d/source/guides/modernize-setup-py-project.rst))