### PR TITLE
deps: Update `twine` from 4.0.2 to 5.1.1

### DIFF
--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -3,5 +3,5 @@
 build==1.2.2.post1
 bumpversion==0.5.3
 setuptools==71.1.0
-twine==4.0.2
+twine==5.1.1
 wheel==0.45.0


### PR DESCRIPTION
- [Software Repository](https://pypi.org/project/twine/5.1.1/)
- [Release notes](https://github.com/pypa/twine/releases/tag/v5.1.1)
- [Changelog](https://github.com/pypa/twine/blob/v5.1.1/docs/changelog.rst#twine-511-2024-06-26)
- [Commits](https://github.com/pypa/twine/compare/4.0.2...v5.1.1)