### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,6 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - "3.8.13"
           - "3.9.16"
           - "3.10.9"
 
@@ -69,7 +68,6 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - "3.8.13"
           - "3.9.16"
           - "3.10.9"
 

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,5 @@ python-pip-install: ## Install Pip
 
 docker-compose-run-test: export COMPOSE_FILE = docker-compose.yml:docker-compose.test.yml
 docker-compose-run-test:  ## Run tests with Docker Compose
-	docker compose run --rm --env TOXENV=py38 -- app-python3.8
 	docker compose run --rm --env TOXENV=py39 -- app-python3.9
 	docker compose run --rm --env TOXENV=py310 -- app-python3.10

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,10 +23,6 @@ services:
         source: .
         target: /opt/app
 
-  app-python3.8:
-    <<: *services-app
-    image: docker.io/library/python:3.8.6
-
   app-python3.9:
     <<: *services-app
     image: docker.io/library/python:3.9.15

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.9
 platform = linux
 mypy_path =
     src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py38,
     py39,
     py310,
 
@@ -13,6 +12,5 @@ commands = coverage run --rcfile=.coveragerc.test.ini runtests.py tests
 deps =
     -r{toxinidir}/requirements_test.txt
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10


### PR DESCRIPTION
- Stop running **tests** for Python **3.8** in CI/CD.
- Remove **explicit** support for Python **3.8** from Python project configuration (`setup.py`, `setup.cfg`, and/or `pyproject.toml`).

Reasons for this change:

- The end of support date of Python **3.8** is **2024-10-07**:
  - [PEP 569 – Python 3.8 Release Schedule → 3.8 Lifespan](https://peps.python.org/pep-0569/#lifespan)
  - [Status of Python versions](https://devguide.python.org/versions/)
- Dependabot end-of-support date for Python **3.8** is **2025-02-05**:
  - [Closing down notice: Dependabot will no longer support Python version 3.8 ← GitHub Changelog](https://github.blog/changelog/2025-01-06-closing-down-notice-dependabot-will-no-longer-support-python-version-3-8/)

Ref: https://app.shortcut.com/cordada/story/12613 [sc-12613]