### PR TITLE
Improve test coverage exclusions

### DIFF
--- a/.coveragerc.test.ini
+++ b/.coveragerc.test.ini
@@ -5,10 +5,10 @@ omit =
 branch = True
 
 [report]
-exclude_lines =
-    pragma: no cover
-    if __name__ == .__main__.
 show_missing = True
+exclude_also =
+  if TYPE_CHECKING:
+  if typing.TYPE_CHECKING:
 
 [xml]
 output = test-reports/coverage/xml/coverage.xml


### PR DESCRIPTION
- Exclude `typing.TYPE_CHECKING`.