### PR TITLE
Remove upper bound on Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "fyndata-django-accounts"
 dependencies = [
   "Django>=4.2",
 ]
-requires-python = ">=3.9, <3.11"
+requires-python = ">=3.9"
 authors = [
   {name = "Fyndata (Fynpal SpA)", email = "no-reply@fyndata.com"},
 ]


### PR DESCRIPTION
This change removes the upper bound on the Python version in `pyproject.toml`.

If we become aware of any incompatibilities with future Python versions, we can always reintroduce the upper bound at that time. This allows users to install the package with any Python version, including future versions, without being blocked by the upper limit.