### PR TITLE
Pin GitHub Action `codecov/codecov-action` to commit hash

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
           make test-coverage-report
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./test-reports/coverage/


### PR DESCRIPTION
Pin `codecov/codecov-action` to commit hash instead of tag to improve supply chain security.

Resolves: https://github.com/cordada/fd-django-accounts/security/code-scanning/7