### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,6 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - "3.9"
           - "3.10"
 
     steps:
@@ -70,7 +69,6 @@ jobs:
     strategy:
       matrix:
         python_version:
-          - "3.9"
           - "3.10"
 
     services:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ History
 unreleased (YYYY-MM-DD)
 +++++++++++++++++++++++
 
+- (PR #399, 2026-04-29) chore: Drop support for Python 3.9
+
 0.18.0 (2026-02-12)
 +++++++++++++++++++
 

--- a/Makefile
+++ b/Makefile
@@ -126,5 +126,4 @@ python-pip-install: ## Install Pip
 
 docker-compose-run-test: export COMPOSE_FILE = docker-compose.yml:docker-compose.test.yml
 docker-compose-run-test:  ## Run tests with Docker Compose
-	docker compose run --rm --env TOXENV=py39 -- app-python3.9
 	docker compose run --rm --env TOXENV=py310 -- app-python3.10

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -23,10 +23,6 @@ services:
         source: .
         target: /opt/app
 
-  app-python3.9:
-    <<: *services-app
-    image: docker.io/library/python:3.9.15
-
   app-python3.10:
     <<: *services-app
     image: docker.io/library/python:3.10.9

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 platform = linux
 mypy_path =
     src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
 ]
 dynamic = ["version"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py39,
     py310,
 
 [testenv]
@@ -12,5 +11,4 @@ commands = coverage run --rcfile=.coveragerc.test.ini runtests.py tests
 deps =
     -r{toxinidir}/requirements_test.txt
 basepython =
-    py39: python3.9
     py310: python3.10


### PR DESCRIPTION
- Stop running **tests** for Python **3.9** in CI/CD.
- Remove **explicit** support for Python **3.9** from Python project configuration (`setup.py`, `setup.cfg`, and/or `pyproject.toml`).
- Compile Python **dependency manifests** with the **next highest** Python version (**3.10**).
- Remove Python **3.9** from **Black** configuration.
- Remove support for Python **3.9** from Mypy configuration.
- Remove support for Python **3.9** from Tox configuration.

Reasons for this change:

- The end of support date of Python **3.9** is **2025-10-31**:
  - [PEP 596 – Python 3.9 Release Schedule → 3.9 Lifespan](https://peps.python.org/pep-0596/#lifespan)
  - [Status of Python versions](https://devguide.python.org/versions/)
  - [Dependabot will no longer support Python version 3.9 - Issue already open](dependabot/dependabot-core#14699)

Ref: https://app.shortcut.com/cordada/story/20068 [sc-20068]
Ref: https://app.shortcut.com/cordada/story/20071 [sc-20071]