### PR TITLE
chore(deps): Restrict python version to <3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "fyndata-django-accounts"
 dependencies = [
   "Django>=4.2",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.9, <3.11"
 authors = [
   {name = "Fyndata (Fynpal SpA)", email = "no-reply@fyndata.com"},
 ]


### PR DESCRIPTION
- restrict python version to <3.11 to prevent not tested versions being selected at release

Ref: https://app.shortcut.com/cordada/story/20071